### PR TITLE
feat(home): add loading state for twitter timeline

### DIFF
--- a/src/routes/Home/Home.tsx
+++ b/src/routes/Home/Home.tsx
@@ -6,8 +6,16 @@ import InfoCard from 'components/UI/InfoCard/InfoCard'
 import { Timeline } from 'react-twitter-widgets'
 import feedbackImage from 'assets/images/feedback.jpg'
 import qaMonthImage from 'assets/images/mes-de-qa.jpg'
+import { useState } from 'react'
+import ClayLoadingIndicator from '@clayui/loading-indicator'
+import { ClayLoadingIndicatorWrapperStyled } from 'assets/styles/containers'
 
 const Home = () => {
+  const [twitterIsLoading, setTwitterIsLoading] = useState(true)
+  const handleTwitterLoad = (): void => {
+    setTwitterIsLoading(false)
+  }
+
   return (
     <div>
       <Hero />
@@ -15,10 +23,16 @@ const Home = () => {
         <UpcomingEvents />
         <PastEvents />
         <GridContainer>
-          <Timeline
-            dataSource={{ sourceType: 'profile', screenName: 'LUGSpain' }}
-            options={{ height: '490' }}
-          />
+          <span className="d-flex flex-column justify-content-center">
+            {twitterIsLoading && (
+              <ClayLoadingIndicator displayType="secondary" size="sm" />
+            )}
+            <Timeline
+              dataSource={{ sourceType: 'profile', screenName: 'LUGSpain' }}
+              onLoad={handleTwitterLoad}
+              options={{ height: '490' }}
+            />
+          </span>
           <InfoCard
             image={feedbackImage}
             imageAlt="Dar Feedback Liferay USer Group Spain"

--- a/src/routes/Home/Home.tsx
+++ b/src/routes/Home/Home.tsx
@@ -8,12 +8,25 @@ import feedbackImage from 'assets/images/feedback.jpg'
 import qaMonthImage from 'assets/images/mes-de-qa.jpg'
 import { useState } from 'react'
 import ClayLoadingIndicator from '@clayui/loading-indicator'
-import { ClayLoadingIndicatorWrapperStyled } from 'assets/styles/containers'
+import styled from 'styled-components'
+
+const TimelineWrapperStyled = styled.div<{ isLoading: boolean }>`
+  height: ${({ isLoading }) => (isLoading ? 0 : 'auto')};
+  overflow: ${({ isLoading }) => (isLoading ? 'hidden' : 'unset')};
+  opacity: ${({ isLoading }) => (isLoading ? 0 : 1)};
+  transition: all 0.25s ease-out;
+`
+
+const FlexWrap = styled.div`
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+`
 
 const Home = () => {
   const [twitterIsLoading, setTwitterIsLoading] = useState(true)
   const handleTwitterLoad = (): void => {
-    setTwitterIsLoading(false)
+    setTimeout(() => setTwitterIsLoading(false), 500)
   }
 
   return (
@@ -23,16 +36,18 @@ const Home = () => {
         <UpcomingEvents />
         <PastEvents />
         <GridContainer>
-          <span className="d-flex flex-column justify-content-center">
+          <FlexWrap>
             {twitterIsLoading && (
               <ClayLoadingIndicator displayType="secondary" size="sm" />
             )}
-            <Timeline
-              dataSource={{ sourceType: 'profile', screenName: 'LUGSpain' }}
-              onLoad={handleTwitterLoad}
-              options={{ height: '490' }}
-            />
-          </span>
+            <TimelineWrapperStyled isLoading={twitterIsLoading}>
+              <Timeline
+                dataSource={{ sourceType: 'profile', screenName: 'LUGSpain' }}
+                onLoad={handleTwitterLoad}
+                options={{ height: '490' }}
+              />
+            </TimelineWrapperStyled>
+          </FlexWrap>
           <InfoCard
             image={feedbackImage}
             imageAlt="Dar Feedback Liferay USer Group Spain"


### PR DESCRIPTION
## Motivation

The Twitter timeline widget delays some seconds on first load.
This PR tries to address that UI problem adding a loading indicator, this way the user does not see a blank block, but a loader while the Timeline is getting fetched.

## How to test

Just load the home page and check the TW timeline widget

![image](https://user-images.githubusercontent.com/19485114/191188760-bf7c62db-1c5c-46b6-a814-76519ef3cedd.png)
