### PR TITLE
Use markdown component for descriptions

### DIFF
--- a/src/components/Events/PastEvents/Grid/PastEventsGridItem/PastEventsGridItem.tsx
+++ b/src/components/Events/PastEvents/Grid/PastEventsGridItem/PastEventsGridItem.tsx
@@ -17,6 +17,7 @@ import capitalize from 'utils/capitalize'
 import { EventDetailsStyled } from 'components/Events/UpcomingEvents/Event/UpcomingEventStyled'
 
 import ClayLabel from '@clayui/label'
+import ReactMarkdown from 'react-markdown'
 
 const PastEventsGridItem = ({ item }: IProps) => {
   const navigate = useNavigate()
@@ -41,7 +42,7 @@ const PastEventsGridItem = ({ item }: IProps) => {
           </ClayLabel>
         </EventDetailsStyled>
         <PastEventGridItemDescription>
-          {item.description}
+          <ReactMarkdown children={item.description} linkTarget="_blank" />
         </PastEventGridItemDescription>
         <PastEventGridItemDetails>
           <ClayButton

--- a/src/components/Events/PastEvents/Grid/PastEventsGridItem/PastEventsGridItemStyled.tsx
+++ b/src/components/Events/PastEvents/Grid/PastEventsGridItem/PastEventsGridItemStyled.tsx
@@ -13,14 +13,18 @@ export const PastEventGridItemStyled = styled.article`
   }
 `
 
-export const PastEventGridItemDescription = styled.p`
+export const PastEventGridItemDescription = styled.div`
   overflow: hidden;
   text-overflow: ellipsis;
   display: -webkit-box;
-  -webkit-line-clamp: 3;
-  line-clamp: 3;
+  -webkit-line-clamp: 4;
+  line-clamp: 4;
   -webkit-box-orient: vertical;
   margin: 16px 0 24px 0;
+
+  p {
+    margin-bottom: 0;
+  }
 `
 
 export const PastEventGridItemDetails = styled.div`

--- a/src/components/Events/UpcomingEvents/Event/UpcomingEvent.tsx
+++ b/src/components/Events/UpcomingEvents/Event/UpcomingEvent.tsx
@@ -12,6 +12,7 @@ import ClayButton from '@clayui/button'
 import ClayLabel from '@clayui/label'
 import formatDate from 'utils/format-date'
 import capitalize from 'utils/capitalize'
+import ReactMarkdown from 'react-markdown'
 
 const UpcomingEvent = ({
   event: { id, image, title, dateTime, description, eventType },
@@ -38,7 +39,7 @@ const UpcomingEvent = ({
           </ClayLabel>
         </EventDetailsStyled>
         <UpcomingEventGridItemDescription>
-          {description}
+          <ReactMarkdown children={description} linkTarget="_blank" />
         </UpcomingEventGridItemDescription>
         <ClayButton
           className="p-0"


### PR DESCRIPTION
This way, the descriptions shown in the grid will render as proper html, with links etc.

![image](https://user-images.githubusercontent.com/19485114/193259368-982ee9d6-cefb-40c8-b464-c98aa8826ecb.png)


Merge after https://github.com/lugspain/portal/pull/13