### PR TITLE
fix: physical events are also in streaming - label in event

### DIFF
--- a/src/utils/event-type-name.ts
+++ b/src/utils/event-type-name.ts
@@ -1,7 +1,7 @@
 const getEventTypeName = (eventType: keyof IOptions): string => {
   const options: IOptions = {
     online: 'Online',
-    physical: 'Presencial',
+    physical: 'Presencial y streaming',
     default: '',
   }
   return options[eventType]


### PR DESCRIPTION
## Motivation

Add `Presencial y streaming` text to labels.
It's more accurate, as events are always available in streaming.

Before this change the text displayed just `Presencial` which can lead to a misunderstanding

![image](https://user-images.githubusercontent.com/106336918/195427507-88a5f7f3-346e-445f-9c74-85ed3d662f80.png)
